### PR TITLE
glossary updates

### DIFF
--- a/app/elements/combat-card.html
+++ b/app/elements/combat-card.html
@@ -40,7 +40,7 @@
 
       <expedition-card title="Prepare for Combat" data-route="prepforcombat" icon="{{icon}}" on-return="prev" dark>
         <template is="dom-if" if="{{globals.helplevel}}">
-          <p>All players must shuffle their ability decks.</p>
+          <p>Shuffle ALL of your abilities back into your deck.</p>
           <p>Draw - but don't look at - the top 3 abilities.</p>
           <p>When you begin combat:</p>
           <ul>
@@ -76,7 +76,7 @@
             Immediately follow the surge action listed on all remaining Encounter cards. Some Encounters' surges may also apply after they've been killed.
           </p>
           <p>
-            Surge effects happen before abilities. Abilities that apply "this round" do not affect surges (but loot still does). If you are killed during a surge, do not resolve your abilities.
+            Surge effects happen before abilities. Abilities that apply "this round" do not affect surges (however, Loot may still be used during a surge). If you are killed during a surge, do not resolve your abilities.
           </p>
         </template>
         <a data-target="combatroll" on-tap="next">Next</a>

--- a/app/elements/tutorial-section.html
+++ b/app/elements/tutorial-section.html
@@ -14,7 +14,7 @@
       <ol>
         <li><strong>Health</strong>: the enemy's starting health.
         <li><strong>Strengths/Weaknesses</strong>: against types of attacks or situations.
-        <li><strong>Surge</strong>: a special attack or action that sometimes happens.
+        <li><strong>Surge</strong>: their special attack, which happens randomly during combat.
         <li><strong>Tier</strong>: indicates difficulty.
       </ol>
     </div>
@@ -22,11 +22,10 @@
     <div id="quest">
       <p>
         <strong>Adventurers</strong> represent you and your party. Every adventurer has their own
-        role and special skills - it's up to you to realize them.
+        strengths - it's up to you to realize them.
       </p>
       <ol>
         <li> <strong>Health</strong>: the amount of health you start with is next to the heart. Use a paper clip to keep track of your current health by sliding it along the edge.
-        <li> <strong>Bonuses</strong>: you get a bonus to any roleplaying rolls that you can make fit these categories.
         <li> <strong>Abilities</strong>: The number and type of your starting combat abilities.
       </ol>
     </div>
@@ -51,14 +50,14 @@
         <li>Use the environment to your advantage - if you find a cloth tent,
         try setting it on fire or ripping through it.
         <li>Creativity applies to combat, too! Your action doesn't have to be an Ability card every round.
-        <li>Try crafting your roleplaying action to fit one of the Skills on your Explorer card to captialize on your roll bonuses.
       </ul>
     </div>
 
     <div id="combatend">
       <p>
-        At the end of some battles, you get <strong>Loot</strong>: tools, weapons, and other tangible items.
-        They can be used at any time to heal, damage enemies, or advance the plot.
+        At the end of some battles, you get <strong>Loot</strong>.
+        Loot can be used at any time - inside or outside of combat - to heal, damage enemies, or advance the plot.
+        Using Loot is instantaneous and does not prevent you from using an ability during combat.
       </p>
       <ol>
         <li><strong>Tier</strong>: the relative power of the loot.
@@ -84,7 +83,7 @@
         Every Encounter is a series of Rounds. Combat continues until one side prevails.
       </p>
       <ul>
-        <li>Every round, you'll play one or more Ability cards to attack the enemy.
+        <li>Every round, you'll play one Ability. (Note: Some Abilities may allow you to play additional cards)
         <li>Choose your abilities quickly - damage increases the longer you deliberate.
         <li>There are no take-backsies. Once you've played a card, that decision is final.
       </ul>

--- a/app/elements/tutorial-section.html
+++ b/app/elements/tutorial-section.html
@@ -86,6 +86,7 @@
         <li>Every round, you'll play one Ability. (Note: Some Abilities may allow you to play additional cards)
         <li>Choose your abilities quickly - damage increases the longer you deliberate.
         <li>There are no take-backsies. Once you've played a card, that decision is final.
+        <li>At the end of each round of combat, re-shuffle all of your Ability cards back into your deck, including the Ability you played this round.
       </ul>
     </div>
 


### PR DESCRIPTION
- specify when surges happen
- remove outdated help on Adventurers
- added clarifications around when you can use loot
- update combat help to state that you play one ability per round, unless otherwise noted