### PR TITLE
Fixed instruction tag in quest parser and fixed malaise instruction tags.

### DIFF
--- a/app/elements/quest-card.html
+++ b/app/elements/quest-card.html
@@ -190,7 +190,12 @@
         this._handleParser(this._parser.choiceEvent(idx));
       },
       _onDialogReturn: function(e) {
-        this._handleParser(this._parser.back(), 'slide-right');
+        var p = this._parser.back();
+        // If we're at the start of the quest, fall back to the default handler.
+        if (p === null) {
+          return;
+        }
+        this._handleParser(p, 'slide-right');
         e.stopPropagation();
       },
       _onPlayerSetupReturn: function(e) {

--- a/app/quests/mistress_malaise.txt
+++ b/app/quests/mistress_malaise.txt
@@ -105,8 +105,10 @@
         Your party quickly takes cover behind some nearby headstones and sneaks towards the group.
       </p>
 
-      <instruction>One of your party must roll a die at this time.</instruction>
-      <instruction>Choose a next action based on the result of that roll:</instruction>
+      <instruction>
+        <p>One of your party must roll a die at this time.</p>
+        <p>Choose a next action based on the result of that roll:</p>
+      </instruction>
 
       <choice>
         Rolled above 10
@@ -319,12 +321,14 @@
   </p>
 </roleplay>
 <roleplay title="The Phylactery">
-  <instruction>Choose up to two players. Those players are the phylactery group.</instruction>
-  <instruction>The phylactery group must only attack the phylactery until it's destroyed. When it is, they may join combat.</instruction>
-  <instruction>The phylactery group does not take round damage, but is still affected by surges.</instruction>
-  <instruction>Players not in the phylactery group may not attack the phylactery.</instruction>
-  <instruction>At this time, draw a tier III Undead encounter and place it face-down with full health. This is the phylactery.</instruction>
-  <instruction>The encounter is over when all enemies and the phylactery are destroyed.</instruction>
+  <instruction>
+    <p>Choose up to two players. Those players are the phylactery group.</p>
+    <p>The phylactery group must only attack the phylactery until it's destroyed. When it is, they may join combat.</p>
+    <p>The phylactery group does not take round damage, but is still affected by surges.</p>
+    <p>Players not in the phylactery group may not attack the phylactery.</p>
+    <p>At this time, draw a tier III Undead encounter and place it face-down with full health. This is the phylactery.</p>
+    <p>The encounter is over when all enemies and the phylactery are destroyed.</p>
+  </instruction>
 </roleplay>
 <encounter icon="undead">
   <e>Lich</e>

--- a/app/scripts/quest_parser.js
+++ b/app/scripts/quest_parser.js
@@ -208,10 +208,11 @@ questParser.prototype._loadDialogNode = function(node) {
 
     // Convert "instruction" tags to <expedition-indicator> tags.
     if (tag === "instruction") {
-      var text = c.childNodes[0];
+      var inner = document.createElement('span');
+      inner.innerHTML = c.innerHTML;
       c = document.createElement('expedition-indicator');
       c.setAttribute('icon', 'adventurer');
-      Polymer.dom(c).appendChild(text)
+      Polymer.dom(c).appendChild(inner);
     }
 
     contents.appendChild(c);


### PR DESCRIPTION
Instruction tag didn't initially allow for paragraph separation of instructions.