### PR TITLE
Change helplevel to difficulty setting

### DIFF
--- a/app/config/globals_src.js
+++ b/app/config/globals_src.js
@@ -1,7 +1,39 @@
 module.exports = {
   adventurers: 4,
-  helplevel: 2,
+  difficulty: 0,
   multitouch: true,
   tutorialVisibility: {},
   encounters: {},
+  difficultySettings: [
+    {
+      name: "Tutorial",
+      roundTimeMillis: 20000,
+      damageMultiplier: 0.5,
+      helpLevel: 2,
+    },
+    {
+      name: "Easy",
+      roundTimeMillis: 15000,
+      damageMultiplier: 0.75,
+      helpLevel: 1,
+    },
+    {
+      name: "Normal",
+      roundTimeMillis: 10000,
+      damageMultiplier: 1.0,
+      helpLevel: 0,
+    },
+    {
+      name: "Hard",
+      roundTimeMillis: 8000,
+      damageMultiplier: 1.5,
+      helpLevel: 0,
+    },
+    {
+      name: "Impossible",
+      roundTimeMillis: 6000,
+      damageMultiplier: 2.0,
+      helpLevel: 0,
+    }
+  ],
 };

--- a/app/elements/combat-card.html
+++ b/app/elements/combat-card.html
@@ -15,7 +15,7 @@
             <expedition-static-input label="{{item.name}}">(Tier {{item.tier}} {{item.class}})</expedition-static-input>
           </template>
         </template>
-        <template is="dom-if" if="{{globals.helplevel}}">
+        <template is="dom-if" if="{{verbose}}">
           <template is="dom-if" if="{{!custom}}">
             <p>Draw the enemies listed above. Place in the center and put tokens on their maximum Health.</p>
           </template>
@@ -39,7 +39,7 @@
       </expedition-card>
 
       <expedition-card title="Prepare for Combat" data-route="prepforcombat" icon="{{icon}}" on-return="prev" dark>
-        <template is="dom-if" if="{{globals.helplevel}}">
+        <template is="dom-if" if="{{verbose}}">
           <p>Shuffle ALL of your abilities back into your deck.</p>
           <p>Draw - but don't look at - the top 3 abilities.</p>
           <p>When you begin combat:</p>
@@ -71,7 +71,7 @@
 
       <expedition-card title="Enemy Surge!" id="surgecard" data-route="combatsurge" icon="{{icon}}" on-return="_returnConfirm" dark>
         <h3>An enemy surge occurs!</h3>
-        <template is="dom-if" if="{{globals.helplevel}}">
+        <template is="dom-if" if="{{verbose}}">
           <p>
             Immediately follow the surge action listed on all remaining Encounter cards. Some Encounters' surges may also apply after they've been killed.
           </p>
@@ -83,10 +83,10 @@
       </expedition-card>
 
       <expedition-card title="Roll &amp; Resolve" data-route="combatroll" icon="{{icon}}" on-return="prev" dark>
-        <template is="dom-if" if="{{!globals.helplevel}}">
+        <template is="dom-if" if="{{!verbose}}">
           Resolve all played abilities.
         </template>
-        <template is="dom-if" if="{{globals.helplevel}}">
+        <template is="dom-if" if="{{verbose}}">
           <p>
             Roll a die for each ability with a "<img class="inline_icon" src="../images/roll_white_small.svg"></img> &gt; X" and resolve the cards' effects.
           </p>
@@ -115,7 +115,7 @@
         <h3>All adventurers:</h3>
         <h3>{{_roundStats.roundDamage}} Damage</h3>
 
-        <template is="dom-if" if="{{globals.helplevel}}">
+        <template is="dom-if" if="{{verbose}}">
           <p>Slide your Adventurer health down {{_roundStats.roundDamage}} space(s).</p>
           <p>If you reach zero health, you are knocked out. After you resolve this turn, you cannot play further cards until the end of the Encounter.</p>
         </template>
@@ -136,7 +136,7 @@
       <expedition-card title="{{endType}}" data-route="combatend" icon="{{icon}}" on-return="return" dark>
         <article>
           <template is="dom-if" if="{{_isVictory}}">
-            <template is="dom-if" if="{{globals.helplevel}}">
+            <template is="dom-if" if="{{verbose}}">
               <p>
                 <strong>All adventurers heal to full health.</strong>
               </p>
@@ -146,7 +146,7 @@
               <p>
                 You feel more knowledgeable! Each Adventurer may learn a new ability at this time:
               </p>
-              <template is="dom-if" if="{{globals.helplevel}}">
+              <template is="dom-if" if="{{verbose}}">
                 <ul>
                   <li>You may discard one of your current abilities.
                   <li>Draw 3 Ability cards from one of the decks listed on your Adventurer card.
@@ -164,7 +164,7 @@
                 <li><strong>Draw {{item.count}} Tier {{item.tierNumeral}} Loot</strong>
               </template>
             </ul>
-            <template is="dom-if" if="{{globals.helplevel}}">
+            <template is="dom-if" if="{{verbose}}">
               <p>Loot drawn at the end of an Encounter is for the entire party. It may either be divided amongst Adventurers or kept in a shared Loot pile.</p>
               <p>Loot can be used at any time and does not cost an action (unless specified).</p>
             </template>
@@ -205,7 +205,8 @@
       is: 'combat-card',
       behaviors: [GlobalsBehaviour],
       listeners: {
-        'pages.animFinish': '_onAnimFinish'
+        'pages.animFinish': '_onAnimFinish',
+        'globals-changed': '_onGlobalChanged',
       },
       ready: function() {
         this._logic = new Encounter();
@@ -282,7 +283,7 @@
             this._logic.resetSurgeCounter();
           }
 
-          this.$.timer.start();
+          this.$.timer.start(this.globals.difficultySettings[this.globals.difficulty]);
           this._logic.beginRound();
         }
         e.stopPropagation();
@@ -341,7 +342,7 @@
       },
       _onTimerStopped: function(e) {
         // Update round stats according to elapsed time.
-        this._roundStats = this._logic.endRound(e.detail);
+        this._roundStats = this._logic.endRound(e.detail, this.globals.difficultySettings[this.globals.difficulty]);
 
         // If was a surge last round, or is now a surge, reroute to surge screen
         // and add surge time to details
@@ -360,6 +361,9 @@
         if (this.$.pages.getCurrentPage() === this.$.pages.initial && !this._isReady) {
           this.ready();
         }
+      },
+      _onGlobalChanged: function() {
+        this.verbose = this.globals.difficultySettings[this.globals.difficulty].helpLevel > 0;
       },
       properties: {
         encounter: {

--- a/app/elements/combat-timer-card.html
+++ b/app/elements/combat-timer-card.html
@@ -17,7 +17,7 @@
         this.active = false;
 
         this._roundTimeRemaining = 0;
-        this._roundTimeTotalMillis = 10000; // starting round time. TODO change based on difficulty
+        this._roundTimeTotalMillis = null; // starting round time (set by difficulty)
         this._roundDamage = 0;
         this._lastAttackMillis = 0;
         this._timerStartMillis = 0;
@@ -40,10 +40,11 @@
         canvas.addEventListener('touchmove', this._touchEvent.bind(this));
         canvas.addEventListener('touchend', this._touchEvent.bind(this));
       },
-      start: function() {
+      start: function(difficulty) {
         this.active = true;
         this._timerStartMillis = Date.now();
         this._lastRenderMillis = this._timerStartMillis;
+        this._roundTimeTotalMillis = difficulty.roundTimeMillis;
         this._roundTimeRemaining = this._roundTimeTotalMillis;
         this._renderLoop();
       },

--- a/app/elements/expedition-settings.html
+++ b/app/elements/expedition-settings.html
@@ -11,19 +11,27 @@
 	<expedition-checkbox label="Multitouch" value="{{globals.multitouch}}">
 		All players must hold their finger on the screen to end combat. Otherwise, a single tap will end combat.
 	</expedition-checkbox>
-	<expedition-picker id="picker" label="Show Help" value="{{globals.helplevel}}">
-		<div id="helpnone">
-			<div>No Help</div>
-			<div>For advanced players only! Hides all instructional text.</div>
+	<expedition-picker id="picker" label="Difficulty" value="{{globals.difficulty}}">
+		<div id="tutorial">
+      <div>Tutorial</div>
+      <div>Recommended for beginners - extra guidance is given.</div>
 		</div>
-		<div id="helpsome">
-			<div>Some Help</div>
-			<div>Hides basic pop-up messages, but keeps the important rules.</div>
+		<div id="easy">
+			<div>Easy</div>
+			<div>Enemies go easy on you, and hints are given for setup and combat.</div>
 		</div>
-		<div id="helpfull">
-			<div>Full Help</div>
-			<div>Recommended for beginners - show rules and descriptive pop-ups.</div>
+		<div id="normal">
+			<div>Normal</div>
+      <div>Expedition as it was meant to be played. Experienced adventurers start here!</div>
 		</div>
+    <div id="hard">
+      <div>Hard</div>
+      <div>Enemies are relentless; a true challenge for seasoned adventurers only.</div>
+    </div>
+    <div id="impossible">
+      <div>Impossible</div>
+      <div>You will almost surely die, so make your death a glorious one!</div>
+    </div>
 	</expedition-picker>
   </template>
   <script>

--- a/app/elements/quest-card.html
+++ b/app/elements/quest-card.html
@@ -147,7 +147,7 @@
         Polymer.dom(this).appendChild(div);
       },
       _onGlobalChanged: function(evt) {
-        if (evt.detail.path === 'globals.helplevel' && this.getEffectiveChildren()[0] !== undefined && !this._parser.isStarted()) {
+        if (evt.detail.path === 'globals.difficulty' && this.getEffectiveChildren()[0] !== undefined && !this._parser.isStarted()) {
           if (evt.detail.value >= 1) {
             this.$.pages.ready();
           } else {

--- a/app/elements/tutorial-dialog.html
+++ b/app/elements/tutorial-dialog.html
@@ -15,7 +15,7 @@
       is: 'tutorial-dialog',
       behaviors: [GlobalsBehaviour],
       tryOpen: function(section) {
-        if (this.globals.helplevel !== 2 || this.globals.tutorialVisibility[section] === false) {
+        if (this.globals.difficultySettings[this.globals.difficulty].helpLevel !== 2 || this.globals.tutorialVisibility[section] === false) {
           return;
         }
         if (!this.$.section.valid(section)) {

--- a/app/scripts/combat_mechanics.js
+++ b/app/scripts/combat_mechanics.js
@@ -88,9 +88,8 @@ Encounter.prototype._randomAttackDamage = function() {
   }
 };
 
-Encounter.prototype._roundAttackDamage = function (s) {
+Encounter.prototype._roundAttackDamage = function (s, difficulty) {
   // enemies each get to hit once - twice if the party took too long
-  // TODO tweak the overtime penalty based on difficulty
   var damage = 0;
   var attackCount = s.tier;
   if (s.timeRemainingMillis < 0) {
@@ -99,7 +98,9 @@ Encounter.prototype._roundAttackDamage = function (s) {
   for (var i = 0; i < attackCount; i++) {
     damage += this._randomAttackDamage();
   }
-  return damage;
+
+  // Scale according to difficulty, then round to whole number.
+  return Math.round(damage * difficulty.damageMultiplier);
 };
 
 function clone(obj) {
@@ -126,7 +127,7 @@ Encounter.prototype.resetSurgeCounter = function() {
   // TODO: This function should take an (optional) number of rounds to reset to.
 };
 
-Encounter.prototype.endRound = function(s) {
+Encounter.prototype.endRound = function(s, difficulty) {
   s = clone(s);
   this._totalTimeMillis += s.turnTimeMillis;
   s.totalTimeMillis = this._totalTimeMillis;
@@ -134,7 +135,7 @@ Encounter.prototype.endRound = function(s) {
   s.expectedDamage = Math.ceil(s.turnTimeMillis * (this._stats.tierDmgRate) / 1000);
   s.nextSurgeRounds = this.getNextSurgeRounds(s.turnTimeMillis);
   s.tier = this.getTier();
-  s.roundDamage = this._roundAttackDamage(s);
+  s.roundDamage = this._roundAttackDamage(s, difficulty);
 
   this._roundLog.push(s);
   return s;

--- a/app/scripts/globals.json
+++ b/app/scripts/globals.json
@@ -1,6 +1,6 @@
 {
   "adventurers": 4,
-  "helplevel": 2,
+  "difficulty": 0,
   "multitouch": true,
   "tutorialVisibility": {},
   "encounters": {
@@ -244,5 +244,37 @@
       "tier": 4,
       "class": "Undead"
     }
-  }
+  },
+  "difficultySettings": [
+    {
+      "name": "Tutorial",
+      "roundTimeMillis": 20000,
+      "damageMultiplier": 0.5,
+      "helpLevel": 2
+    },
+    {
+      "name": "Easy",
+      "roundTimeMillis": 15000,
+      "damageMultiplier": 0.75,
+      "helpLevel": 1
+    },
+    {
+      "name": "Normal",
+      "roundTimeMillis": 10000,
+      "damageMultiplier": 1,
+      "helpLevel": 0
+    },
+    {
+      "name": "Hard",
+      "roundTimeMillis": 7000,
+      "damageMultiplier": 1.5,
+      "helpLevel": 0
+    },
+    {
+      "name": "Impossible",
+      "roundTimeMillis": 5000,
+      "damageMultiplier": 2,
+      "helpLevel": 0
+    }
+  ]
 }


### PR DESCRIPTION
The help settings are now included inside of globals.difficultySettings. The difficultySettings object is passed to the combat timer (on start to set the round duration) and to combat_mechanics (on round end to scale the damage dealt).